### PR TITLE
Send/cancel comments, and a bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ It’s currently an early work-in-progress, but you might still find it handy. C
 | Shortcut                              | Command
 | ------------------------------------- | ---------------------------------------------------
 | `Ctrl+Enter` (or `y`)                 | Apply most popular suggestion & move to next
-| `1`–`5`                               | Apply the n-th suggestion & move to next
+| `1` – `5`                             | Apply the n-th suggestion & move to next
 | `Tab` / `Shift+Tab` (or `h` / `l`)    | Cycle linked phrases/strings
 | `PageUp` / `PageDown` (or `k` / `j`)  | Move up/down
 | `Ctrl+A` (or `i`)                     | Add a new translation
-| `Ctrl+Enter`                          | Submit translation
-| `Esc`                                 | Cancel translation
 | `Ctrl+E` (or `c`)                     | Edit the first suggestion
 | `/`                                   | Search
+| `Ctrl+Enter`                          | Submit translation (or comment)
+| `Esc`                                 | Cancel translation (or comment)
 
 …and more to come.
 

--- a/telegram-translation-shortcuts.user.js
+++ b/telegram-translation-shortcuts.user.js
@@ -4,13 +4,15 @@
 // @description  Adds useful keyboard shortcuts to the Telegram Translation Platform
 // @author       Juraj Fiala
 // @include      https://translations.telegram.org/*
-// @version      0.4.0
+// @version      0.4.1
 // @grant        none
+// @run-at       document-start
 // @downloadURL  https://github.com/jurf/telegram-translation-shortcuts/raw/master/telegram-translation-shortcuts.user.js
 // @updateURL    https://github.com/jurf/telegram-translation-shortcuts/raw/master/telegram-translation-shortcuts.user.js
 // ==/UserScript==
 
 /* global LangKeys, KeyboardEvent, Keys */
+// var activeCommentItem = 0
 
 /**
  * Returns the current app name (not yet used)
@@ -98,10 +100,18 @@ function inSuggestionField () {
 }
 
 /**
+ * Returns whether activeElement is 'comment-field'
+ */
+function inCommentField () {
+  // activeCommentItem = Array.from(document.getElementsByClassName('comment-field')).indexOf(document.activeElement)
+  return document.activeElement.classList.contains('comment-field')
+}
+
+/**
  * The wrapper ('key-add-suggestion-wrap') contains elements needed to submit a new translation.
  * If the wrapper is closed, it's class-name changes to 'key-add-suggestion-wrap collapsed'
  *
- * @returns True if open; Focus to the input-form
+ * @returns True if open; and will focus to the input-form
  * @returns False if collapsed/closed
  */
 function isInputTranslationOpen () {
@@ -134,22 +144,35 @@ function editTranslation () {
 /**
  * Clicks the cancel button
  */
-function cancelTranslation () {
+function cancel () {
   if (inSuggestionField()) {
     const ZeroOrLast = isTranslator() // 0 if translator
     getCancelBtns().item(ZeroOrLast).click()
     getCancelBtns().item(ZeroOrLast).focus() // Don't let input keep focus & prevent other shortcuts
+  } else
+  if (inCommentField()) {
+    const formbtns = document.activeElement.nextElementSibling.children.item(0).children
+    document.activeElement.form.reset()
+    formbtns.item(1).click() // Clicks 'cancel' for animation
+    // document.getElementsByClassName('key-suggestion-value-wrap').item(activeCommentItem).click() // Collapse the comments
   }
 }
 
 /**
  * Clicks the submit button
  */
-function submitTranslation () {
+function submit () {
   if (inSuggestionField()) {
     const ZeroOrLast = isTranslator()
     getSubmitBtns().item(ZeroOrLast).click()
     getCancelBtns().item(ZeroOrLast).focus() // Focus to cancel button to prevent re-submit on 'Enter' keypress
+  } else
+  if (inCommentField()) {
+    const formbtns = document.activeElement.nextElementSibling.children.item(0).children
+    if (formbtns.item(0).classList.contains('form-submit-btn')) {
+      formbtns.item(0).focus() // Good UX
+      formbtns.item(0).click() // Send
+    } // ignore?
   }
 }
 
@@ -197,10 +220,15 @@ function quickApply (index) {
 }
 
 /**
- * Clicks the search icon
+ * Focus on current context search field
  */
 function openSearch () {
-  document.getElementsByClassName('header-search-btn').item(0).click()
+  var isPopupHidden = document.getElementsByClassName('popup-container').item(0).classList.contains('hide')
+  if (isPopupHidden | undefined | null) {
+    document.getElementsByClassName('header-search-btn').item(0).click()
+  } else {
+    document.getElementsByClassName('tr-popup-search-field').item(0).focus()
+  }
 }
 
 /**
@@ -208,21 +236,30 @@ function openSearch () {
  * @param {KeyboardEvent} e - event to handle
  */
 function handleShortcut (e) {
+  if (!e.isTrusted) return // Only accept events from humans
+  const eClassList = e.target.classList
   // INSIDE FORM INPUTS
-  if (e.target.classList.contains('form-control')) {
-    // Only within translation inputs
-    if (document.activeElement.classList.contains('tr-form-control')) {
+  if (eClassList.contains('form-control')) {
+    // Only within translation / comment inputs
+    if (eClassList.contains('tr-form-control') || eClassList.contains('comment-field')) {
       // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
       switch (e.key) {
         // Cancel
-        case 'Escape': // Using 'Escape | Esc' will make it useless
-          if (!e.ctrlKey) cancelTranslation(); else return
-          // FIXME: Doesn't work in search results
+        case 'Escape': // Try to Use 'Escape | Esc' inside an if()
+          if (!e.ctrlKey) {
+            e.stopImmediatePropagation()
+            e.preventDefault()
+            cancel() // needs @run-at  document-start to work
+          } else return
           break
 
         // Submit or Send
         case 'Enter':
-          if (e.ctrlKey) submitTranslation(); else return
+          if (e.ctrlKey) {
+            e.stopImmediatePropagation()
+            e.preventDefault()
+            submit()
+          } else return
           break
 
         default:
@@ -306,7 +343,11 @@ function handleShortcut (e) {
       if (!e.ctrlKey) quickApply(-1); else matchedKey = false
       break
     case 'Enter':
-      if (e.ctrlKey) quickApply(-1); else matchedKey = false
+      if (!e.ctrlKey && document.activeElement.classList.contains('form-submit-btn')) {
+        e.stopImmediatePropagation() // prevent form-resubmit
+      } else if (e.ctrlKey) {
+        quickApply(-1)
+      } else matchedKey = false
       break
 
     // Open search


### PR DESCRIPTION
- This update will make the script to run at document-start
- ctrl+enter and Esc now support comment buttons
- escape to cancel works properly inside search results, fixes #9
- '/' to search works in change language popup